### PR TITLE
Add frontend search interface with category browsing

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -1,0 +1,18 @@
+.bpi-container{background:#F3ECE299;padding:2rem;}
+.bpi-search-form{max-width:600px;margin:0 auto 2rem;display:flex;flex-wrap:wrap;gap:0.5rem;}
+.bpi-search-form input[type="text"],
+.bpi-search-form select{flex:1 1 200px;padding:0.5rem;border:1px solid #ccc;border-radius:4px;}
+.bpi-search-form button{padding:0.5rem 1rem;border:none;background:#8b5e3c;color:#fff;border-radius:4px;cursor:pointer;}
+.bpi-main-category{margin-bottom:2rem;}
+.bpi-main-category h2{margin-bottom:0.5rem;}
+.bpi-subcategory-scroll{display:flex;overflow-x:auto;gap:1rem;padding-bottom:1rem;}
+.bpi-subcategory-scroll::-webkit-scrollbar{height:6px;}
+.bpi-subcategory-scroll::-webkit-scrollbar-thumb{background:#ccc;border-radius:3px;}
+.bpi-subcard{background:#fff;border-radius:8px;padding:0.5rem 1rem;white-space:nowrap;text-decoration:none;color:#333;box-shadow:0 1px 3px rgba(0,0,0,0.1);}
+.bpi-results-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(250px,1fr));gap:1rem;}
+.bpi-result-card{background:#fff;border-radius:8px;padding:1rem;box-shadow:0 1px 3px rgba(0,0,0,0.1);cursor:pointer;}
+.bpi-result-card h3{margin-top:0;margin-bottom:0.5rem;}
+.bpi-modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;z-index:999;}
+.bpi-modal.open{display:flex;}
+.bpi-modal-content{background:#fff;padding:1.5rem;border-radius:8px;max-width:500px;width:90%;max-height:80%;overflow:auto;position:relative;}
+.bpi-close{position:absolute;top:0.5rem;right:0.5rem;font-size:1.5rem;cursor:pointer;}

--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', function(){
+    const catSelect = document.getElementById('bpi_cat');
+    const subSelect = document.getElementById('bpi_sub');
+    if(catSelect && subSelect){
+        catSelect.addEventListener('change', function(){
+            const parent = this.value;
+            subSelect.innerHTML = '<option value="">'+subSelect.getAttribute('data-placeholder')+'</option>';
+            if(!parent){return;}
+            fetch('/wp-json/wp/v2/bpi_category?parent='+parent)
+                .then(res=>res.json())
+                .then(data=>{
+                    data.forEach(term=>{
+                        const opt=document.createElement('option');
+                        opt.value=term.id;
+                        opt.textContent=term.name;
+                        subSelect.appendChild(opt);
+                    });
+                });
+        });
+    }
+
+    // modal handling
+    const modal = document.getElementById('bpi-modal');
+    const modalBody = modal ? modal.querySelector('.bpi-modal-body') : null;
+    document.querySelectorAll('.bpi-result-card').forEach(card=>{
+        card.addEventListener('click', function(){
+            if(!modal || !modalBody){return;}
+            modalBody.innerHTML = this.querySelector('.bpi-card-details').innerHTML;
+            modal.classList.add('open');
+        });
+    });
+    if(modal){
+        modal.addEventListener('click', function(e){
+            if(e.target.classList.contains('bpi-close') || e.target === modal){
+                modal.classList.remove('open');
+            }
+        });
+    }
+});

--- a/inc/Base/BajaPublicInformationEnqueue.php
+++ b/inc/Base/BajaPublicInformationEnqueue.php
@@ -13,31 +13,43 @@ class BajaPublicInformationEnqueue extends BajaPublicInformationBaseController
 {
 	
 
-	public function registerFunction(){
+        public function registerFunction(){
 
-		add_action('admin_enqueue_scripts', array($this, 'customFiles'));
+                add_action('admin_enqueue_scripts', array($this, 'customFiles'));
 
-		add_action("wp_ajax_setBajaPublicInformation", array($this, "setBajaPublicInformation" ) );
+                // front-end assets
+                add_action('wp_enqueue_scripts', array($this, 'publicFiles'));
 
-		add_action("wp_ajax_nopriv_setBajaPublicInformation", array($this, "setBajaPublicInformation") );
+                add_action("wp_ajax_setBajaPublicInformation", array($this, "setBajaPublicInformation" ) );
 
-	}
+                add_action("wp_ajax_nopriv_setBajaPublicInformation", array($this, "setBajaPublicInformation") );
 
-	public function customFiles(){
+        }
 
-		/*
-		* load custom styles and scripts
-		*/
-		wp_enqueue_style('translator', $this->pluginUrl.'assets/bpi.css');
-		//wp_enqueue_script('translator', $this->pluginUrl.'assets/translator.js', array( 'jquery' ));
+        public function customFiles(){
 
-		/**
-		 * Ajax handle
-		 */
-	  	wp_enqueue_script( 'ajaxHandle', plugin_dir_url(dirname(__FILE__, 3)).'bajapublicinformation/assets/bpi.js', array( 'jquery' ));
-	  	wp_localize_script( 'ajaxHandle', 'ajax_object', array( 'ajaxurl' => admin_url( 'admin-ajax.php' ) ) );
+                /*
+                * load custom styles and scripts for admin
+                */
+                wp_enqueue_style('translator', $this->pluginUrl.'assets/bpi.css');
 
-	}
+                /**
+                 * Ajax handle
+                 */
+                wp_enqueue_script( 'ajaxHandle', plugin_dir_url(dirname(__FILE__, 3)).'bajapublicinformation/assets/bpi.js', array( 'jquery' ));
+                wp_localize_script( 'ajaxHandle', 'ajax_object', array( 'ajaxurl' => admin_url( 'admin-ajax.php' ) ) );
+
+        }
+
+        /**
+         * Enqueue public facing assets
+         */
+        public function publicFiles(){
+
+                wp_enqueue_style('bpi-front', $this->pluginUrl.'assets/frontend.css', array(), null);
+                wp_enqueue_script('bpi-front', $this->pluginUrl.'assets/frontend.js', array('jquery'), null, true);
+
+        }
 
 	public function setBajaPublicInformation(){
 


### PR DESCRIPTION
## Summary
- Load new public CSS/JS assets for frontend usage
- Implement shortcode with search form, category browsing, result cards, and modal
- Add styles and scripts for search UI, scrolling categories, and modal behavior

## Testing
- `php -l inc/Base/BajaPublicInformationEnqueue.php`
- `php -l inc/Base/BpiCustomPostType.php`


------
https://chatgpt.com/codex/tasks/task_e_68a31f7ce88c832592e1214502d28d16