### PR TITLE
Implement AJAX live search with category dropdown

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -16,3 +16,16 @@
 .bpi-modal.open{display:flex;}
 .bpi-modal-content{background:#fff;padding:1.5rem;border-radius:8px;max-width:500px;width:90%;max-height:80%;overflow:auto;position:relative;}
 .bpi-close{position:absolute;top:0.5rem;right:0.5rem;font-size:1.5rem;cursor:pointer;}
+
+.bpi-search-card{max-width:600px;margin:0 auto;background:#fff;padding:2rem;border-radius:8px;}
+.bpi-input-wrapper{position:relative;}
+#bpi-live-search{width:100%;padding:0.75rem 2.5rem 0.75rem 0.75rem;border:1px solid #ccc;border-radius:4px;}
+.bpi-search-icon{position:absolute;right:0.75rem;top:50%;transform:translateY(-50%);pointer-events:none;}
+.bpi-category-dropdown{margin-top:1rem;}
+.bpi-category-list{list-style:none;margin:0;padding:0;background:#fff;border:1px solid #ccc;display:inline-block;}
+.bpi-category-list>li{padding:0.5rem 1rem;position:relative;cursor:pointer;white-space:nowrap;}
+.bpi-category-list>li:hover{background:#f0f0f0;}
+.bpi-sub-list{list-style:none;margin:0;padding:0;position:absolute;left:100%;top:0;background:#fff;border:1px solid #ccc;display:none;}
+.bpi-cat-item:hover>.bpi-sub-list{display:block;}
+.bpi-sub-list li{padding:0.5rem 1rem;cursor:pointer;white-space:nowrap;}
+.bpi-sub-list li:hover{background:#f0f0f0;}

--- a/inc/Base/BajaPublicInformationEnqueue.php
+++ b/inc/Base/BajaPublicInformationEnqueue.php
@@ -48,6 +48,7 @@ class BajaPublicInformationEnqueue extends BajaPublicInformationBaseController
 
                 wp_enqueue_style('bpi-front', $this->pluginUrl.'assets/frontend.css', array(), null);
                 wp_enqueue_script('bpi-front', $this->pluginUrl.'assets/frontend.js', array('jquery'), null, true);
+                wp_localize_script('bpi-front', 'bpiAjax', array('ajax_url' => admin_url('admin-ajax.php')));
 
         }
 


### PR DESCRIPTION
## Summary
- Replace `bpi_search` shortcode with card-based search input and category dropdown
- Add jQuery-powered live search via AJAX, including modal results
- Style search card and category menu

## Testing
- `composer validate`
- `php -l inc/Base/BpiCustomPostType.php`
- `php -l inc/Base/BajaPublicInformationEnqueue.php`


------
https://chatgpt.com/codex/tasks/task_e_68a324de2c28832586a720ee746cfb19