### PR TITLE
Add collapsible category filter panel

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -21,8 +21,12 @@
 .bpi-input-wrapper{position:relative;}
 #bpi-live-search{width:100%;padding:0.75rem 2.5rem 0.75rem 0.75rem;border:1px solid #ccc;border-radius:4px;}
 .bpi-search-icon{position:absolute;right:0.75rem;top:50%;transform:translateY(-50%);pointer-events:none;}
-.bpi-category-dropdown{margin-top:1rem;}
-.bpi-category-list{list-style:none;margin:0;padding:0;background:#fff;border:1px solid #ccc;display:inline-block;}
+.bpi-category-dropdown{margin-top:1rem;position:relative;}
+.bpi-category-toggle{background:#fff;border:1px solid #ccc;padding:0.5rem 1rem;width:100%;text-align:left;cursor:pointer;display:flex;justify-content:space-between;align-items:center;}
+.bpi-arrow{transition:transform 0.3s;}
+.bpi-category-dropdown.open .bpi-arrow{transform:rotate(180deg);}
+.bpi-category-list{list-style:none;margin:0;padding:0;background:#fff;border:1px solid #ccc;display:none;}
+.bpi-category-dropdown.open .bpi-category-list{display:block;}
 .bpi-category-list>li{padding:0.5rem 1rem;position:relative;cursor:pointer;white-space:nowrap;}
 .bpi-category-list>li:hover{background:#f0f0f0;}
 .bpi-sub-list{list-style:none;margin:0;padding:0;position:absolute;left:100%;top:0;background:#fff;border:1px solid #ccc;display:none;}

--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -2,11 +2,16 @@ jQuery(document).ready(function($){
     let selectedCat = 0;
     let selectedSub = 0;
 
+    $('#bpi-category-toggle').on('click', function(){
+        $('.bpi-category-dropdown').toggleClass('open');
+    });
+
     $('.bpi-cat-item').on('click', function(e){
         selectedCat = $(this).data('id');
         selectedSub = 0;
         $('.bpi-cat-item, .bpi-sub-item').removeClass('selected');
         $(this).addClass('selected');
+        $('.bpi-category-dropdown').removeClass('open');
         e.stopPropagation();
     });
 
@@ -15,6 +20,7 @@ jQuery(document).ready(function($){
         selectedSub = $(this).data('id');
         $('.bpi-sub-item').removeClass('selected');
         $(this).addClass('selected');
+        $('.bpi-category-dropdown').removeClass('open');
         e.stopPropagation();
     });
 

--- a/inc/Base/BpiCustomPostType.php
+++ b/inc/Base/BpiCustomPostType.php
@@ -211,6 +211,9 @@ class BpiCustomPostType extends BajaPublicInformationBaseController
                 <span class="bpi-search-icon">&#128269;</span>
             </div>
             <div class="bpi-category-dropdown">
+                <button type="button" id="bpi-category-toggle" class="bpi-category-toggle">
+                    <?php _e('Kategória szűrés', 'bpi'); ?> <span class="bpi-arrow">&#9660;</span>
+                </button>
                 <ul class="bpi-category-list">
                     <?php foreach ($top_terms as $term) :
                         $subs = get_terms([


### PR DESCRIPTION
## Summary
- Add "Kategória szűrés" toggle button with arrow and collapsible category list
- Style category filter panel to show categories on demand and rotate arrow when open
- Handle dropdown toggling and close after category selection on the front end

## Testing
- ✅ `php -l inc/Base/BpiCustomPostType.php`
- ⚠️ `composer validate` (license warning)
- ⚠️ `npm test` (package.json missing)


------
https://chatgpt.com/codex/tasks/task_e_68a328170ac08325a49cedc2e8c58de4