### PR TITLE
Display selected categories in search

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -50,13 +50,16 @@
 .bpi-category-toggle {
     background: #fff;
     cursor: pointer;
-    justify-content: space-between;
     color: #613A24;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
 }
 .bpi-arrow {
   font-size: 10px; /* kísérletezd ki */
   line-height: 1;
   color: #613A2499;
+  margin-left: auto;
 }
 .bpi-category-dropdown.open .bpi-arrow{transform:rotate(180deg);}
 /* közös beállítások */
@@ -126,5 +129,25 @@
 }
 .bpi-sub-item:hover {
   background: #f0f6ff;
+  color: #098FDB;
+}
+
+.bpi-badge {
+  background: #f0f6ff;
+  color: #098FDB;
+  border-radius: 12px;
+  padding: 0.2rem 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+.bpi-badge .bpi-remove-sub {
+  cursor: pointer;
+}
+
+.bpi-cat-item.selected::before,
+.bpi-sub-item.selected::before {
+  content: "\2713";
+  margin-right: 0.5rem;
   color: #098FDB;
 }

--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -4,6 +4,8 @@ jQuery(document).ready(function($){
 
   const $dropdown = $('.bpi-category-dropdown');
   const $list = $('.bpi-category-list');
+  const $selectedMain = $('#bpi-selected-main');
+  const $selectedSub = $('#bpi-selected-sub');
 
   // Toggle gomb
   $('#bpi-category-toggle').on('click', function(e){
@@ -42,10 +44,24 @@ jQuery(document).ready(function($){
 
   // Megakadályozzuk, hogy mobilon a fő katt zárja a teljes dropdownt
   $('.bpi-cat-item').on('click', function(e){
+    if ($(e.target).closest('.bpi-sub-list').length){
+      return;
+    }
+    e.stopPropagation();
+    selectedCat = $(this).data('id');
+    selectedSub = 0;
+    $('.bpi-cat-item').removeClass('selected');
+    $('.bpi-sub-item').removeClass('selected');
+    $(this).addClass('selected');
+    $selectedMain.text('Kategória: ' + $(this).data('name'));
+    $selectedSub.hide().empty();
+
     if (isMobile()){
-      e.stopPropagation();
       $(this).toggleClass('open')
              .siblings('.bpi-cat-item').removeClass('open');
+    } else {
+      $dropdown.removeClass('open');
+      $list.stop(true, true).slideUp(150);
     }
   });
 
@@ -59,13 +75,50 @@ jQuery(document).ready(function($){
   // Alkategória választás
   $('.bpi-sub-item').on('click', function(e){
     e.stopPropagation();
-    selectedCat = $(this).closest('.bpi-cat-item').data('id');
+    const $cat = $(this).closest('.bpi-cat-item');
+    selectedCat = $cat.data('id');
     selectedSub = $(this).data('id');
     $('.bpi-sub-item').removeClass('selected');
+    $('.bpi-cat-item').removeClass('selected');
     $(this).addClass('selected');
+    $cat.addClass('selected');
+    $selectedMain.text('Kategória: ' + $cat.data('name'));
+    $selectedSub.html($(this).data('name') + ' <span class="bpi-remove-sub">&times;</span>').show();
 
     $dropdown.removeClass('open');
     $list.stop(true, true).slideUp(150);
+  });
+
+  $('.bpi-category-list > .bpi-item-default').on('click', function(e){
+    e.stopPropagation();
+    selectedCat = 0;
+    selectedSub = 0;
+    $('.bpi-cat-item, .bpi-sub-item').removeClass('selected');
+    $selectedMain.text('Kategória');
+    $selectedSub.hide().empty();
+    $dropdown.removeClass('open');
+    $list.stop(true, true).slideUp(150);
+  });
+
+  $('.bpi-sub-list > .bpi-item-default').on('click', function(e){
+    e.stopPropagation();
+    const $cat = $(this).closest('.bpi-cat-item');
+    selectedCat = $cat.data('id');
+    selectedSub = 0;
+    $('.bpi-cat-item').removeClass('selected');
+    $('.bpi-sub-item').removeClass('selected');
+    $cat.addClass('selected');
+    $selectedMain.text('Kategória: ' + $cat.data('name'));
+    $selectedSub.hide().empty();
+    $dropdown.removeClass('open');
+    $list.stop(true, true).slideUp(150);
+  });
+
+  $selectedSub.on('click', '.bpi-remove-sub', function(e){
+    e.stopPropagation();
+    selectedSub = 0;
+    $('.bpi-sub-item').removeClass('selected');
+    $selectedSub.hide().empty();
   });
 
   // --- MODÁL ---

--- a/inc/Base/BajaPublicInformationCustomPostType.php
+++ b/inc/Base/BajaPublicInformationCustomPostType.php
@@ -212,7 +212,9 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
             </div>
             <div class="bpi-category-dropdown">
                 <span id="bpi-category-toggle" class="bpi-category-toggle">
-                    <?php _e('Kategória', 'bpi'); ?> <span class="bpi-arrow">&#9660;</span>
+                    <span id="bpi-selected-main"><?php _e('Kategória', 'bpi'); ?></span>
+                    <span id="bpi-selected-sub" class="bpi-badge" style="display:none;"></span>
+                    <span class="bpi-arrow">&#9660;</span>
                 </span>
                 <ul class="bpi-category-list">
                     <li class="bpi-item-default">Összes kategória</li>
@@ -223,13 +225,13 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
                             'hide_empty' => false,
                         ]);
                     ?>
-                        <li class="bpi-cat-item" data-id="<?php echo esc_attr($term->term_id); ?>">
+                        <li class="bpi-cat-item" data-id="<?php echo esc_attr($term->term_id); ?>" data-name="<?php echo esc_attr($term->name); ?>">
                             <?php echo esc_html($term->name); ?>
                             <?php if (!empty($subs)) : ?>
                                 <ul class="bpi-sub-list">
                                     <li class="bpi-item-default">Összes alkategória</li>
                                     <?php foreach ($subs as $sub) : ?>
-                                        <li class="bpi-sub-item" data-id="<?php echo esc_attr($sub->term_id); ?>"><?php echo esc_html($sub->name); ?></li>
+                                        <li class="bpi-sub-item" data-id="<?php echo esc_attr($sub->term_id); ?>" data-name="<?php echo esc_attr($sub->name); ?>"><?php echo esc_html($sub->name); ?></li>
                                     <?php endforeach; ?>
                                 </ul>
                             <?php endif; ?>


### PR DESCRIPTION
## Summary
- show selected main category and removable subcategory badge next to dropdown
- mark chosen categories with checkmarks and new badge styling
- update scripts to manage selection state and allow subcategory removal

## Testing
- `php -l inc/Base/BajaPublicInformationCustomPostType.php`
- `composer test` *(fails: Command "test" is not defined)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a44d6cd528832582a3e2cc6d602eb1