### PR TITLE
Style result cards and mask phone numbers

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -10,8 +10,15 @@
 .bpi-subcategory-scroll::-webkit-scrollbar-thumb{background:#ccc;border-radius:3px;}
 .bpi-subcard{background:#fff;border-radius:8px;padding:0.5rem 1rem;white-space:nowrap;text-decoration:none;color:#333;box-shadow:0 1px 3px rgba(0,0,0,0.1);}
 .bpi-results-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(250px,1fr));gap:1rem;}
-.bpi-result-card{background:#fff;border-radius:8px;padding:1rem;box-shadow:0 1px 3px rgba(0,0,0,0.1);cursor:pointer;}
+#bpi-live-results{margin-top:1rem;}
+.bpi-result-card{background:#fff;border-radius:8px;padding:1rem;box-shadow:0 1px 3px rgba(0,0,0,0.1);}
 .bpi-result-card h3{margin-top:0;margin-bottom:0.5rem;}
+.bpi-card-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:0.5rem;}
+.bpi-card-category{font-weight:600;color:#613A24;}
+.bpi-open-modal img{width:16px;height:16px;cursor:pointer;}
+.bpi-field{display:flex;align-items:center;gap:0.5rem;margin-bottom:0.25rem;color:#613A24;}
+.bpi-field img{width:16px;height:16px;}
+.bpi-phone-toggle img{width:16px;height:16px;cursor:pointer;}
 .bpi-modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;z-index:999;}
 .bpi-modal.open{display:flex;}
 .bpi-modal-content{background:#fff;padding:1.5rem;border-radius:8px;max-width:500px;width:90%;max-height:80%;overflow:auto;position:relative;}

--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -126,8 +126,9 @@ jQuery(document).ready(function($){
     const $modal = $('#bpi-modal');
     const $modalBody = $modal.find('.bpi-modal-body');
 
-    $('.bpi-result-card').off('click').on('click', function(){
-      $modalBody.html($(this).find('.bpi-card-details').html());
+    $('.bpi-open-modal').off('click').on('click', function(e){
+      e.stopPropagation();
+      $modalBody.html($(this).closest('.bpi-result-card').find('.bpi-card-details').html());
       $modal.addClass('open');
     });
 
@@ -135,6 +136,15 @@ jQuery(document).ready(function($){
       if($(e.target).hasClass('bpi-close') || e.target === this){
         $modal.removeClass('open');
       }
+    });
+  }
+
+  function bindPhoneToggle(){
+    $('.bpi-phone-toggle').off('click').on('click', function(e){
+      e.stopPropagation();
+      const $num = $(this).siblings('.bpi-phone-number');
+      $num.text($num.data('full'));
+      $(this).remove();
     });
   }
 
@@ -153,8 +163,10 @@ jQuery(document).ready(function($){
     }, function(response){
       $('#bpi-live-results').html(response);
       bindModal();
+      bindPhoneToggle();
     });
   });
 
   bindModal();
+  bindPhoneToggle();
 });

--- a/assets/img/eye.svg
+++ b/assets/img/eye.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M2.062 12.348a1 1 0 0 1 0-.696 10.75 10.75 0 0 1 19.876 0 1 1 0 0 1 0 .696 10.75 10.75 0 0 1-19.876 0" />
+  <circle cx="12" cy="12" r="3" />
+</svg>

--- a/assets/img/map-pin.svg
+++ b/assets/img/map-pin.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0" />
+  <circle cx="12" cy="10" r="3" />
+</svg>

--- a/assets/img/phone.svg
+++ b/assets/img/phone.svg
@@ -1,0 +1,13 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384" />
+</svg>

--- a/assets/img/zoom-in.svg
+++ b/assets/img/zoom-in.svg
@@ -1,0 +1,16 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="11" cy="11" r="8" />
+  <line x1="21" x2="16.65" y1="21" y2="16.65" />
+  <line x1="11" x2="11" y1="8" y2="14" />
+  <line x1="8" x2="14" y1="11" y2="11" />
+</svg>

--- a/inc/Base/BajaPublicInformationCustomPostType.php
+++ b/inc/Base/BajaPublicInformationCustomPostType.php
@@ -239,9 +239,9 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
                     <?php endforeach; ?>
                 </ul>
             </div>
-            <div id="bpi-live-results"></div>
-            <div id="bpi-modal" class="bpi-modal"><div class="bpi-modal-content"><span class="bpi-close">&times;</span><div class="bpi-modal-body"></div></div></div>
         </div>
+        <div id="bpi-live-results"></div>
+        <div id="bpi-modal" class="bpi-modal"><div class="bpi-modal-content"><span class="bpi-close">&times;</span><div class="bpi-modal-body"></div></div></div>
         <?php
         return ob_get_clean();
     }
@@ -285,17 +285,35 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
                 $phone   = get_post_meta(get_the_ID(), 'bpi_phone', true);
                 $website = get_post_meta(get_the_ID(), 'bpi_website', true);
                 $email   = get_post_meta(get_the_ID(), 'bpi_email', true);
+                $streets = get_post_meta(get_the_ID(), 'bpi_streets', true);
                 $extra   = get_post_meta(get_the_ID(), 'bpi_extra', true);
+                $cats    = get_the_terms(get_the_ID(), 'bpi_category');
+                $catName = ($cats && !is_wp_error($cats)) ? $cats[0]->name : '';
+
                 echo '<div class="bpi-result-card">';
+                echo '<div class="bpi-card-header">';
+                if ($catName) {
+                    echo '<span class="bpi-card-category">' . esc_html($catName) . '</span>';
+                }
+                echo '<span class="bpi-open-modal"><img src="' . esc_url($this->pluginUrl . 'assets/img/zoom-in.svg') . '" alt="' . esc_attr__('Részletek', 'bpi') . '"></span>';
+                echo '</div>';
                 echo '<h3>' . get_the_title() . '</h3>';
-                if ($address) {
-                    echo '<p>' . esc_html($address) . '</p>';
+                if ($streets) {
+                    echo '<div class="bpi-field bpi-streets"><img src="' . esc_url($this->pluginUrl . 'assets/img/map-pin.svg') . '" alt="" /><span>' . esc_html($streets) . '</span></div>';
+                }
+                if ($phone) {
+                    $prefix = substr($phone, 0, 6);
+                    $masked = trim($prefix) . ' / xxx xxxx';
+                    echo '<div class="bpi-field bpi-phone"><img src="' . esc_url($this->pluginUrl . 'assets/img/phone.svg') . '" alt="" /><span class="bpi-phone-number" data-full="' . esc_attr($phone) . '">' . esc_html($masked) . '</span><span class="bpi-phone-toggle"><img src="' . esc_url($this->pluginUrl . 'assets/img/eye.svg') . '" alt="" /></span></div>';
                 }
                 echo '<div class="bpi-card-details" style="display:none;">';
                 echo '<h3>' . get_the_title() . '</h3>';
                 if ($address) {
                     echo '<p><strong>' . __('Cím', 'bpi') . ':</strong> ' . esc_html($address) . '</p>';
                     echo '<iframe width="100%" height="200" src="https://www.google.com/maps?q=' . urlencode($address) . '&output=embed"></iframe>';
+                }
+                if ($streets) {
+                    echo '<p><strong>' . __('Körzet utcái', 'bpi') . ':</strong> ' . esc_html($streets) . '</p>';
                 }
                 if ($phone) {
                     echo '<p><strong>' . __('Telefon', 'bpi') . ':</strong> ' . esc_html($phone) . '</p>';


### PR DESCRIPTION
## Summary
- Display search results outside the search card and redesign result cards.
- Show category, streets with map icon, and masked phone numbers with reveal button.
- Add modal trigger and supporting scripts/styles with new SVG icons.

## Testing
- `php -l inc/Base/BajaPublicInformationCustomPostType.php`


------
https://chatgpt.com/codex/tasks/task_e_68a45daa517c8325b9ab2710b71d23ee