### PR TITLE
Add results header and street filtering

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -152,3 +152,10 @@
   transform: translateY(-50%);
   color: #098FDB;
 }
+
+.bpi-results-info{margin-bottom:1rem;}
+.bpi-results-info .bpi-subcategory{font-weight:600;}
+.bpi-results-info .bpi-main-category{text-align:center;font-weight:600;}
+.bpi-results-count{text-align:center;margin:0.5rem 0;}
+.bpi-question{margin-bottom:0.5rem;}
+#bpi-street-search{width:100%;border:1px solid #E7E1DE;border-radius:5px;height:40px;margin-bottom:1rem;}

--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -138,6 +138,18 @@ jQuery(document).ready(function($){
     });
   }
 
+  function bindStreetFilter(){
+    $('#bpi-street-search').on('input', function(){
+      const street = $(this).val().toLowerCase();
+      $('.bpi-result-card').each(function(){
+        const streets = ($(this).data('streets') || '').toLowerCase();
+        $(this).toggle(streets.indexOf(street) !== -1);
+      });
+      const count = $('.bpi-result-card:visible').length;
+      $('.bpi-results-count').text('Találatok: ' + count);
+    });
+  }
+
   // Live search
   $('#bpi-live-search').on('input', function(){
     const term = $(this).val();
@@ -153,6 +165,7 @@ jQuery(document).ready(function($){
     }, function(response){
       $('#bpi-live-results').html(response);
       bindModal();
+      bindStreetFilter();
     });
   });
 

--- a/inc/Base/BajaPublicInformationCustomPostType.php
+++ b/inc/Base/BajaPublicInformationCustomPostType.php
@@ -278,6 +278,19 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
         ];
         $query = new \WP_Query($args);
         if ($query->have_posts()) {
+            $sub_name = $sub ? get_term($sub, 'bpi_category') : '';
+            $cat_name = $cat ? get_term($cat, 'bpi_category') : '';
+            echo '<div class="bpi-results-info">';
+            if ($sub_name && !is_wp_error($sub_name)) {
+                echo '<div class="bpi-subcategory">' . esc_html($sub_name->name) . '</div>';
+            }
+            if ($cat_name && !is_wp_error($cat_name)) {
+                echo '<div class="bpi-main-category">' . esc_html($cat_name->name) . '</div>';
+            }
+            echo '<div class="bpi-results-count">' . sprintf(__('Találatok: %d', 'bpi'), $query->found_posts) . '</div>';
+            echo '<p class="bpi-question">' . __('Melyik a körzeti háziorvosom?', 'bpi') . '</p>';
+            echo '<input type="text" id="bpi-street-search" placeholder="' . esc_attr__('Írja be az utca nevét..', 'bpi') . '" />';
+            echo '</div>';
             echo '<div class="bpi-results-grid">';
             while ($query->have_posts()) {
                 $query->the_post();
@@ -286,7 +299,8 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
                 $website = get_post_meta(get_the_ID(), 'bpi_website', true);
                 $email   = get_post_meta(get_the_ID(), 'bpi_email', true);
                 $extra   = get_post_meta(get_the_ID(), 'bpi_extra', true);
-                echo '<div class="bpi-result-card">';
+                $streets = get_post_meta(get_the_ID(), 'bpi_streets', true);
+                echo '<div class="bpi-result-card" data-streets="' . esc_attr($streets) . '">';
                 echo '<h3>' . get_the_title() . '</h3>';
                 if ($address) {
                     echo '<p>' . esc_html($address) . '</p>';


### PR DESCRIPTION
## Summary
- show selected category names, result count and street search above results
- filter visible results client-side by typed street name

## Testing
- `php -l inc/Base/BajaPublicInformationCustomPostType.php`


------
https://chatgpt.com/codex/tasks/task_e_68a45e100d588325a07d08325c1c07db