### PR TITLE
Align modal details with result card icons

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -52,6 +52,7 @@
 .bpi-modal.open{display:flex;}
 .bpi-modal-content{background:#fff;padding:1.5rem;border-radius:8px;max-width:500px;width:90%;max-height:80%;overflow:auto;position:relative;}
 .bpi-close{position:absolute;top:0.5rem;right:0.5rem;font-size:1.5rem;cursor:pointer;}
+.bpi-modal-body .bpi-card-category{margin-bottom:0.5rem;}
 
 .bpi-search-card{
 	max-width: 869px;

--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -154,6 +154,7 @@ jQuery(document).ready(function($){
       e.stopPropagation();
       $modalBody.html($(this).closest('.bpi-result-card').find('.bpi-card-details').html());
       $modal.addClass('open');
+      bindPhoneToggle();
     });
 
     $modal.off('click').on('click', function(e){

--- a/inc/Base/BajaPublicInformationCustomPostType.php
+++ b/inc/Base/BajaPublicInformationCustomPostType.php
@@ -323,13 +323,19 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
                     echo '</div>';
                 }
                 echo '<div class="bpi-card-details" style="display:none;">';
+                if ($category) {
+                    echo '<div class="bpi-card-category">' . esc_html($category) . '</div>';
+                }
                 echo '<h3>' . get_the_title() . '</h3>';
                 if ($address) {
-                    echo '<p><strong>' . __('Cím', 'bpi') . ':</strong> ' . esc_html($address) . '</p>';
+                    echo '<div class="bpi-field"><img src="' . esc_url($this->pluginUrl . 'assets/img/map-pin.svg') . '" alt=""><span>' . __('Cím', 'bpi') . ': ' . esc_html($address) . '</span></div>';
                     echo '<iframe width="100%" height="200" src="https://www.google.com/maps?q=' . urlencode($address) . '&output=embed"></iframe>';
                 }
                 if ($phone) {
-                    echo '<p><strong>' . __('Telefon', 'bpi') . ':</strong> ' . esc_html($phone) . '</p>';
+                    echo '<div class="bpi-field"><img src="' . esc_url($this->pluginUrl . 'assets/img/phone.svg') . '" alt="">';
+                    echo '<span class="bpi-phone-number" data-full="' . esc_attr($phone) . '" data-mask="' . esc_attr($masked_phone) . '">' . esc_html($masked_phone) . '</span>';
+                    echo '<span class="bpi-phone-toggle"><img src="' . esc_url($this->pluginUrl . 'assets/img/eye.svg') . '" alt="' . esc_attr__('Telefonszám megjelenítése', 'bpi') . '"></span>';
+                    echo '</div>';
                 }
                 if ($website) {
                     echo '<p><a href="' . esc_url($website) . '" target="_blank">' . esc_html($website) . '</a></p>';


### PR DESCRIPTION
## Summary
- Show category badge, address, and phone fields with icons inside modal
- Enable phone reveal toggle in modal
- Add margin for modal category badge

## Testing
- `php -l inc/Base/BajaPublicInformationCustomPostType.php`
- `node --check assets/frontend.js`

------
https://chatgpt.com/codex/tasks/task_e_68a47c4b63b483259ab8b151bfc365a2