### PR TITLE
Fix modal category alignment

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -58,7 +58,10 @@
     font-size: 1.5rem;
     cursor: pointer;
 }
-.bpi-modal-body .bpi-card-category{margin-bottom:0.5rem;}
+.bpi-modal-body .bpi-card-category{
+    margin-bottom:0.5rem;
+    display:inline-flex;
+}
 
 .bpi-search-card{
 	max-width: 869px;


### PR DESCRIPTION
## Summary
- keep modal category badge from stretching full width by using inline flex

## Testing
- `composer validate --no-check-all`


------
https://chatgpt.com/codex/tasks/task_e_68a485b1b90883259efb5be0bdf3ffe8