### PR TITLE
Enable subcard arrow hover image swap

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -315,14 +315,6 @@
 	border: 1px solid #99C2D7;
 	box-shadow: 0px 4px 18px rgba(0, 0, 0, 0.15);
 }
-.bpi-subcard:hover .bpi-subcard-arrow {
-  	/*position: absolute;
-    transform: rotate(42deg);
-    bottom: -0.4rem;
-    right: -0.3rem;
-    width: 26px;*/
-    background-image: url("../assets/img/arrow-circle-right.svg");
-}
 .bpi-subcard:hover h4 {
   color: #5C7481; /* csak akkor változik, ha a kártya van hover alatt */
 }

--- a/inc/Base/BajaPublicInformationCustomPostType.php
+++ b/inc/Base/BajaPublicInformationCustomPostType.php
@@ -254,7 +254,13 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
                         <?php foreach ($subs as $sub) : ?>
                             <div class="bpi-subcard" data-parent="<?php echo esc_attr($term->term_id); ?>" data-id="<?php echo esc_attr($sub->term_id); ?>">
                                 <h4><?php echo esc_html($sub->name); ?></h4>
-                                <img class="bpi-subcard-arrow" src="<?php echo esc_url($this->pluginUrl . 'assets/img/arrow-circle-up-right.svg'); ?>" />
+                                <img
+                                    class="bpi-subcard-arrow"
+                                    src="<?php echo esc_url($this->pluginUrl . 'assets/img/arrow-circle-up-right.svg'); ?>"
+                                    data-src-default="<?php echo esc_url($this->pluginUrl . 'assets/img/arrow-circle-up-right.svg'); ?>"
+                                    data-src-hover="<?php echo esc_url($this->pluginUrl . 'assets/img/arrow-circle-right.svg'); ?>"
+                                    alt=""
+                                />
                             </div>
                         <?php endforeach; ?>
                     </div>


### PR DESCRIPTION
## Summary
- allow hover swapping of subcategory arrow icons via data attributes
- drop unused CSS rule for hover arrow background

## Testing
- `php -l inc/Base/BajaPublicInformationCustomPostType.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6dc659830832585606b4bd97a3086