### PR TITLE
Hide category cards during search or category filtering

### DIFF
--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -20,8 +20,10 @@ jQuery(document).ready(function($){
     const term = $('#bpi-live-search').val();
     if(term.length < 3 && selectedCat === 0 && selectedSub === 0){
       $('#bpi-live-results').empty();
+      $('#bpi-category-cards').show();
       return;
     }
+    $('#bpi-category-cards').hide();
     $.post(bpiAjax.ajax_url, {
       action: 'bpi_live_search',
       keyword: term,


### PR DESCRIPTION
## Summary
- Hide default category cards when running a search or choosing categories
- Restore category cards when no search term or category filter is active

## Testing
- `npm test` *(fails: Could not read package.json)*
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68a6e9f0093883259725da2dcea6d172