### PR TITLE
Add zoomable featured images to result cards

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -19,12 +19,12 @@
 }
 #bpi-live-results{margin-top:1rem;}
 .bpi-result-card{
-	background:#fff;
-	border-radius:8px;
-	padding:1rem;
-	box-shadow:0 1px 3px rgba(0,0,0,0.1);
-	width: 456px;
-	height: 168px;
+        background:#fff;
+        border-radius:8px;
+        padding:1rem;
+        box-shadow:0 1px 3px rgba(0,0,0,0.1);
+        width: 456px;
+        min-height: 168px;
 }
 .bpi-result-card h3{
 	margin-top:0;
@@ -46,6 +46,11 @@
     line-height: 24px;
 }
 .bpi-open-modal img{width:16px;height:16px;cursor:pointer;}
+.bpi-card-image{position:relative;margin-bottom:0.5rem;}
+.bpi-card-image img{width:100%;height:auto;border-radius:4px;}
+.bpi-open-image{position:absolute;top:0.5rem;left:0.5rem;cursor:pointer;background:rgba(255,255,255,0.8);border-radius:4px;padding:2px;}
+.bpi-open-image img{width:16px;height:16px;}
+.bpi-image-wrapper img{max-width:100%;height:auto;}
 .bpi-field{display:flex;align-items:center;gap:0.5rem;margin-bottom:0.25rem;color:#613A24;}
 .bpi-field img{width:16px;height:16px;}
 .bpi-phone-toggle img{width:16px;height:16px;cursor:pointer;}

--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -32,6 +32,7 @@ jQuery(document).ready(function($){
       bindModal();
       bindStreetFilter();
       bindPhoneToggle();
+      bindImageModal();
     });
   }
 
@@ -164,11 +165,31 @@ jQuery(document).ready(function($){
       $modalBody.html($(this).closest('.bpi-result-card').find('.bpi-card-details').html());
       $modal.addClass('open');
       bindPhoneToggle();
+      bindImageModal();
     });
 
     $modal.off('click').on('click', function (e) {
       if ($(e.target).closest('.bpi-close').length || e.target === this) {
         $modal.removeClass('open');
+      }
+    });
+  }
+
+  function bindImageModal(){
+    const $modal = $('#bpi-image-modal');
+    const $wrapper = $modal.find('.bpi-image-wrapper');
+
+    $('.bpi-open-image').off('click').on('click', function(e){
+      e.stopPropagation();
+      const full = $(this).data('full');
+      $wrapper.html('<img src="'+full+'" alt="" />');
+      $modal.addClass('open');
+    });
+
+    $modal.off('click').on('click', function(e){
+      if ($(e.target).closest('.bpi-close').length || e.target === this) {
+        $modal.removeClass('open');
+        $wrapper.empty();
       }
     });
   }
@@ -208,4 +229,5 @@ function bindStreetFilter(){
 
   bindModal();
   bindPhoneToggle();
+  bindImageModal();
 });

--- a/inc/Base/BajaPublicInformationCustomPostType.php
+++ b/inc/Base/BajaPublicInformationCustomPostType.php
@@ -269,6 +269,7 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
         </div>
         <div id="bpi-live-results"></div>
         <div id="bpi-modal" class="bpi-modal"><div class="bpi-modal-content"><span class="bpi-close"><img class="search-icon" src="<?php echo esc_url($this->pluginUrl . 'assets/img/circle-close.svg'); ?>" alt="Search" /></span><div class="bpi-modal-body"></div></div></div>
+        <div id="bpi-image-modal" class="bpi-modal"><div class="bpi-modal-content"><span class="bpi-close"><img class="search-icon" src="<?php echo esc_url($this->pluginUrl . 'assets/img/circle-close.svg'); ?>" alt="Close" /></span><div class="bpi-image-wrapper"></div></div></div>
         <?php
         return ob_get_clean();
     }
@@ -339,6 +340,15 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
                 }
                 echo '<div class="bpi-open-modal"><img src="' . esc_url($this->pluginUrl . 'assets/img/zoom-in.svg') . '" alt="' . esc_attr__('Részletek', 'bpi') . '"></div>';
                 echo '</div>';
+                if (has_post_thumbnail()) {
+                    $thumb_id  = get_post_thumbnail_id();
+                    $thumb_url = wp_get_attachment_image_url($thumb_id, 'medium');
+                    $full_url  = wp_get_attachment_image_url($thumb_id, 'full');
+                    echo '<div class="bpi-card-image">';
+                    echo '<img src="' . esc_url($thumb_url) . '" alt="">';
+                    echo '<span class="bpi-open-image" data-full="' . esc_url($full_url) . '"><img src="' . esc_url($this->pluginUrl . 'assets/img/zoom-in.svg') . '" alt="' . esc_attr__('Kép nagyítása', 'bpi') . '"></span>';
+                    echo '</div>';
+                }
                 echo '<h3>' . get_the_title() . '</h3>';
                 if ($streets) {
                     echo '<div class="bpi-field"><img src="' . esc_url($this->pluginUrl . 'assets/img/map-pin.svg') . '" alt=""><span>' . __('Körzet utcái: ', 'bpi') . esc_html($streets) . '</span></div>';
@@ -354,6 +364,15 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
                     echo '<div class="bpi-card-category">' . esc_html($category) . '</div>';
                 }
                 echo '<h3>' . get_the_title() . '</h3>';
+                if (has_post_thumbnail()) {
+                    $thumb_id  = get_post_thumbnail_id();
+                    $thumb_url = wp_get_attachment_image_url($thumb_id, 'medium');
+                    $full_url  = wp_get_attachment_image_url($thumb_id, 'full');
+                    echo '<div class="bpi-card-image">';
+                    echo '<img src="' . esc_url($thumb_url) . '" alt="">';
+                    echo '<span class="bpi-open-image" data-full="' . esc_url($full_url) . '"><img src="' . esc_url($this->pluginUrl . 'assets/img/zoom-in.svg') . '" alt="' . esc_attr__('Kép nagyítása', 'bpi') . '"></span>';
+                    echo '</div>';
+                }
 
                 if ($phone) {
                     echo '<div class="bpi-field"><img src="' . esc_url($this->pluginUrl . 'assets/img/phone.svg') . '" alt="">';


### PR DESCRIPTION
## Summary
- show featured images in result cards with a zoom icon
- add image modal and styles for enlarged viewing
- enable JavaScript handlers for opening full-size images

## Testing
- `composer validate`
- `php -l inc/Base/BajaPublicInformationCustomPostType.php`


------
https://chatgpt.com/codex/tasks/task_e_68a6eae651048325a31bf471fd2164a3