### PR TITLE
Allow full-size images in modal

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -57,21 +57,22 @@
 	position:absolute;top:0.5rem;left:0.5rem;cursor:pointer;border-radius:4px;padding:2px;
 }
 .bpi-open-image img{width:16px;height:16px;}
-.bpi-image-wrapper img{max-width:100%;height:auto;}
+.bpi-image-wrapper{display:flex;align-items:center;justify-content:center;}
+.bpi-image-wrapper img{max-width:none;max-height:none;width:auto;height:auto;}
 .bpi-field{display:flex;align-items:center;gap:0.5rem;margin-bottom:0.25rem;color:#613A24;}
 .bpi-field img{width:16px;height:16px;}
 .bpi-phone-toggle img{width:16px;height:16px;cursor:pointer;}
 .bpi-modal{display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;z-index:999;}
 .bpi-modal.open{display:flex;}
 .bpi-modal-content{
-	background:#fff;
-	padding:1.5rem;
-	border-radius:8px;
-	max-width:500px;
-	width:90%;
-	max-height:80%;
-	overflow:auto;
-	position:relative;
+        background:#fff;
+        padding:1.5rem;
+        border-radius:8px;
+        position:relative;
+        display:flex;
+        align-items:center;
+        justify-content:center;
+        overflow:auto;
 }
 .bpi-close{
 	position: absolute;


### PR DESCRIPTION
## Summary
- Remove max-width and max-height constraints from image modal
- Center modal images using flex layout

## Testing
- `composer test` (fails: Command "test" is not defined)

------
https://chatgpt.com/codex/tasks/task_e_68a6f35d1ff48325abd4f46eefcc3dce