### PR TITLE
Add alphabetical sort button for search results

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -280,14 +280,23 @@
   margin-top: 50px;
 }
 .bpi-results-count{
-	text-align:center;
-	margin:0.5rem 0;
+        text-align:center;
+        margin:0.5rem 0;
+}
+.bpi-sort-button{
+        padding:0.5rem 1rem;
+        border:none;
+        background:#8b5e3c;
+        color:#fff;
+        border-radius:4px;
+        cursor:pointer;
+        margin-bottom:1rem;
 }
 .bpi-question{
-	margin-bottom:0.7rem;
-	text-align: center;
-	color: #2037A6;
-	text-decoration: underline;
+        margin-bottom:0.7rem;
+        text-align: center;
+        color: #2037A6;
+        text-decoration: underline;
 }
 
 .bpi-street-input-wrapper{

--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -35,6 +35,7 @@ jQuery(document).ready(function($){
       bindStreetFilter();
       bindPhoneToggle();
       bindImageModal();
+      bindSort();
     });
   }
 
@@ -223,6 +224,21 @@ function bindStreetFilter(){
     });
   }
 
+function bindSort(){
+    $('#bpi-sort-alpha').off('click').on('click', function(){
+      const $grid = $('.bpi-results-grid');
+      const $cards = $grid.children('.bpi-result-card').get();
+      $cards.sort(function(a, b){
+        const textA = $(a).find('h3').text().toLowerCase();
+        const textB = $(b).find('h3').text().toLowerCase();
+        return textA.localeCompare(textB);
+      });
+      $.each($cards, function(_, card){
+        $grid.append(card);
+      });
+    });
+  }
+
   // Live search
   $('#bpi-live-search').on('input', performSearch);
 
@@ -237,4 +253,5 @@ function bindStreetFilter(){
   bindModal();
   bindPhoneToggle();
   bindImageModal();
+  bindSort();
 });

--- a/inc/Base/BajaPublicInformationCustomPostType.php
+++ b/inc/Base/BajaPublicInformationCustomPostType.php
@@ -324,6 +324,8 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
                 echo '</div>';
             }
 
+            echo '</div>'; // .bpi-results-info
+            echo '<button id="bpi-sort-alpha" class="bpi-sort-button">' . __('Rendezés ABC szerint', 'bpi') . '</button>';
             echo '<div class="bpi-results-grid">';
             while ($query->have_posts()) {
                 $query->the_post();


### PR DESCRIPTION
## Summary
- close search results info block and add "Rendezés ABC szerint" button above results
- style new sort button for frontend
- implement client-side sorting to reorder results alphabetically

## Testing
- `php -l inc/Base/BajaPublicInformationCustomPostType.php`
- `node --check assets/frontend.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6fb04df7083258c4156230ff3e877