### PR TITLE
Align sort button to right above results grid

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -283,6 +283,9 @@
         text-align:center;
         margin:0.5rem 0;
 }
+.bpi-sort-wrapper{
+        text-align:right;
+}
 .bpi-sort-button{
         padding:0.5rem 1rem;
         border:none;

--- a/inc/Base/BajaPublicInformationCustomPostType.php
+++ b/inc/Base/BajaPublicInformationCustomPostType.php
@@ -325,7 +325,7 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
             }
 
             echo '</div>'; // .bpi-results-info
-            echo '<span id="bpi-sort-alpha" class="bpi-sort-button">' . __('Rendezés ABC szerint', 'bpi') . '</span>';
+            echo '<div class="bpi-sort-wrapper"><span id="bpi-sort-alpha" class="bpi-sort-button">' . __('Rendezés ABC szerint', 'bpi') . '</span></div>';
             echo '<div class="bpi-results-grid">';
             while ($query->have_posts()) {
                 $query->the_post();


### PR DESCRIPTION
## Summary
- Move sort button into a wrapper and render it before the results grid
- Add CSS to right-align the sort button above the results grid

## Testing
- `php -l inc/Base/BajaPublicInformationCustomPostType.php`

------
https://chatgpt.com/codex/tasks/task_e_68a700d967808325a2fb94e0404b2dc8