### PR TITLE
Enable toggle for result sorting

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -404,3 +404,6 @@
 .bpi-sort-icon{
   width: 12px;                 /* állítsd a méretet */
 }
+#bpi-sort-alpha.desc .bpi-sort-icon{
+  transform: rotate(180deg);
+}

--- a/assets/frontend.js
+++ b/assets/frontend.js
@@ -10,6 +10,7 @@ jQuery(document).ready(function($){
 
   let selectedCat = 0;
   let selectedSub = 0;
+  let sortAsc = true;
 
   const $dropdown = $('.bpi-category-dropdown');
   const $list = $('.bpi-category-list');
@@ -231,11 +232,13 @@ function bindSort(){
       $cards.sort(function(a, b){
         const textA = $(a).find('h3').text().toLowerCase();
         const textB = $(b).find('h3').text().toLowerCase();
-        return textA.localeCompare(textB);
+        return sortAsc ? textA.localeCompare(textB) : textB.localeCompare(textA);
       });
       $.each($cards, function(_, card){
         $grid.append(card);
       });
+      sortAsc = !sortAsc;
+      $('#bpi-sort-alpha').toggleClass('desc', !sortAsc);
     });
   }
 


### PR DESCRIPTION
## Summary
- allow sort button to toggle between ascending and descending order
- rotate sort icon when descending

## Testing
- `composer validate --no-check-publish`


------
https://chatgpt.com/codex/tasks/task_e_68a705bf27088325b65334a7fe0bd5f6