### PR TITLE
Improve frontend mobile responsiveness

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -434,3 +434,28 @@
 .phonex {
   color: #16376066; /* szürke X */
 }
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+  .bpi-results-grid {
+    grid-template-columns: 1fr;
+    max-width: 100%;
+  }
+  .bpi-result-card {
+    width: 100%;
+  }
+  .bpi-search-card {
+    padding: 1rem;
+  }
+  .bpi-subcategories-grid {
+    justify-content: center;
+  }
+  .bpi-subcard {
+    width: 100%;
+  }
+  .bpi-modal-content {
+    width: 95%;
+    min-width: 0;
+    padding: 1rem;
+  }
+}

--- a/inc/Base/BajaPublicInformationEnqueue.php
+++ b/inc/Base/BajaPublicInformationEnqueue.php
@@ -50,6 +50,16 @@ class BajaPublicInformationEnqueue extends BajaPublicInformationBaseController
                 wp_enqueue_script('bpi-front', $this->pluginUrl.'assets/frontend.js', array('jquery'), null, true);
                 wp_localize_script('bpi-front', 'bpiAjax', array('ajax_url' => admin_url('admin-ajax.php')));
 
+                // Ensure proper scaling on mobile devices
+                add_action('wp_head', array($this, 'addViewportMeta'));
+
+        }
+
+        /**
+         * Output viewport meta tag for responsive layouts
+         */
+        public function addViewportMeta(){
+                echo '<meta name="viewport" content="width=device-width, initial-scale=1" />';
         }
 
 	public function setBajaPublicInformation(){


### PR DESCRIPTION
## Summary
- Inject viewport meta tag to ensure proper scaling on mobile devices
- Add responsive CSS rules so search results and modals adapt on small screens

## Testing
- `composer validate`
- `php -l inc/Base/BajaPublicInformationEnqueue.php`


------
https://chatgpt.com/codex/tasks/task_e_68a72efb85688325a5ff2ca22e58d8df