### PR TITLE
Show address on result card

### DIFF
--- a/inc/Base/BajaPublicInformationCustomPostType.php
+++ b/inc/Base/BajaPublicInformationCustomPostType.php
@@ -462,8 +462,8 @@ class BajaPublicInformationCustomPostType extends BajaPublicInformationBaseContr
                     }
                     echo '</div>';
                 }
-                if ($streets) {
-                    echo '<div class="bpi-field"><img src="' . esc_url($this->pluginUrl . 'assets/img/map-pin.svg') . '" alt=""><span>' . __('Körzet utcái: ', 'bpi') . esc_html($streets) . '</span></div>';
+                if ($address) {
+                    echo '<div class="bpi-field"><img src="' . esc_url($this->pluginUrl . 'assets/img/map-pin.svg') . '" alt=""><span>' . __('Cím', 'bpi') . ': ' . esc_html($address) . '</span></div>';
                 }
                 if ($phone) {
                     echo '<div class="bpi-field"><img src="' . esc_url($this->pluginUrl . 'assets/img/phone.svg') . '" alt="">';


### PR DESCRIPTION
## Summary
- Display address instead of district streets on result cards
- Ensure modal displays both district streets and address

## Testing
- `php -l inc/Base/BajaPublicInformationCustomPostType.php`


------
https://chatgpt.com/codex/tasks/task_e_68a841a1c8488325a9c8c6ec449a8894