### PR TITLE
Make subcategory grid horizontally scrollable on mobile

### DIFF
--- a/assets/frontend.css
+++ b/assets/frontend.css
@@ -448,10 +448,13 @@
     padding: 1rem;
   }
   .bpi-subcategories-grid {
-    justify-content: center;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    justify-content: flex-start;
   }
   .bpi-subcard {
-    width: 100%;
+    flex: 0 0 auto;
   }
   .bpi-modal-content {
     width: 95%;


### PR DESCRIPTION
## Summary
- Keep desktop layout for subcategory cards on mobile
- Allow horizontal scrolling of subcategory cards on small screens

## Testing
- `composer validate --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68a84a870b9883259ea208941c158ece